### PR TITLE
Single instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TailTool
 ========
 
-Find todays logs and open them with your preferred tail.exe
+Find today's logs and open them with your preferred tail.exe
 
 
 Usage:
@@ -9,6 +9,7 @@ Usage:
       tailtool.exe
       -f=<log search path> 
       -a=<csv of anti words> Any fragments of these words will be ignored. useful for -a=trace to ignore trace files
+      -s Force all log files to be passed as a single argument to your tail tool (eg. if it supports files in tabs)
       -h, -?, --help
 
 

--- a/TailTool/Framework.Core/HotFileFinder.cs
+++ b/TailTool/Framework.Core/HotFileFinder.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-//using Kraken.Framework.Core.Extensions;
 using Kraken.Framework.Core.Extensions;
 using NLog;
 

--- a/TailTool/Framework.Core/KrakenProcess.cs
+++ b/TailTool/Framework.Core/KrakenProcess.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using NLog;
 
 namespace Kraken.Framework.Core

--- a/TailTool/Framework.Core/TailerProcess.cs
+++ b/TailTool/Framework.Core/TailerProcess.cs
@@ -4,7 +4,6 @@ using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
 namespace Kraken.Framework.Core.Processes
 {
@@ -19,6 +18,12 @@ namespace Kraken.Framework.Core.Processes
         public void Start(string logFile)
         {
             Arguments = string.Format("\"{0}\"", logFile);
+            Start();
+        }
+
+        public void Start(List<String> logFiles)
+        {
+            Arguments = String.Join(" ", logFiles.Select(l => string.Format("\"{0}\"", l)));
             Start();
         }
 

--- a/TailTool/Program/CommandLineOptions.cs
+++ b/TailTool/Program/CommandLineOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace TailTool
 {
@@ -10,6 +9,8 @@ namespace TailTool
         public string SearchFolder { get; set; }
 
         public List<string> AntiWords { get; set; }
+
+        public bool SingleInstance { get; set; }
 
         public bool ShowHelp { get; set; }
 

--- a/TailTool/Program/CommandLineParser.cs
+++ b/TailTool/Program/CommandLineParser.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using NDesk.Options;
 
 namespace TailTool
@@ -15,8 +12,9 @@ namespace TailTool
             var commandLineArguments = new CommandLineOptions();
 
             OptionSet = new OptionSet {
-   	            { "f=|folder=",        v => commandLineArguments.SearchFolder = v },
-                { "a=|antiWords=",     v => { commandLineArguments.SetAntiWords(v); }},
+   	            { "f=|folder=",     v => commandLineArguments.SearchFolder = v },
+                { "a=|antiWords=",  v => { commandLineArguments.SetAntiWords(v); }},
+                { "s|single",       v => commandLineArguments.SingleInstance = true },
    	            { "h|?|help",       v => commandLineArguments.ShowHelp = true },
                };
 

--- a/TailTool/Program/Program.cs
+++ b/TailTool/Program/Program.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Kraken.Framework.Core;
 using Kraken.Framework.Core.Processes;
 using NLog;
@@ -32,7 +30,15 @@ namespace TailTool
                 var matchingFiles = fileFinder.FindMatches();
 
                 var wintail = new TailerProcess();
-                matchingFiles.OrderByDescending(x => x.FullName).ToList().ForEach(f => wintail.Start(f.FullName));
+
+                if (options.SingleInstance)
+                {
+                    wintail.Start(matchingFiles.OrderByDescending(x => x.FullName).Select(x => x.FullName).ToList());
+                }
+                else
+                {
+                    matchingFiles.OrderByDescending(x => x.FullName).ToList().ForEach(f => wintail.Start(f.FullName));
+                }
             }
 
         }


### PR DESCRIPTION
Supports passing all log files to a single instance of a tail tool as command line arguments. Use -s to turn on.
