### PR TITLE
Supports new -x command line option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TailTool
 ========
 
-Find today's logs and open them with your preferred tail.exe
+Find the most recent logs (usually today's logs) and open them with your preferred tail.exe
 
 
 Usage:
@@ -9,9 +9,11 @@ Usage:
       tailtool.exe
       -f=<log search path> 
       -a=<csv of anti words> Any fragments of these words will be ignored. useful for -a=trace to ignore trace files
+      -x=<csv or filename patterns> A comma or semicolon separated list of filename patterns to match (eg. *.log,*.txt)
       -s Force all log files to be passed as a single argument to your tail tool (eg. if it supports files in tabs)
       -h, -?, --help
 
+Default filename extension to match is *.log if not specified.
 
 Set the path to your preferred tailer.exe in app.config. 
 

--- a/TailTool/Framework.Core/HotFileFinder.cs
+++ b/TailTool/Framework.Core/HotFileFinder.cs
@@ -22,7 +22,7 @@ namespace Kraken.Framework.Core
 
         public string SearchFolder { get; set; }
 
-        public string FilenamePattern { get; set; }
+        public List<string> FilenamePattern { get; set; }
 
         public List<string> AntiFilenamePattern { get; set; }
 
@@ -33,6 +33,7 @@ namespace Kraken.Framework.Core
         public HotFileFinder()
         {
             AntiFilenamePattern = new List<string>();
+            FilenamePattern = new List<string>();
         }
 
         #endregion
@@ -47,7 +48,14 @@ namespace Kraken.Framework.Core
                 return new List<FileInfo>();
             }
 
-            string[] files = Directory.GetFiles(SearchFolder, FilenamePattern, SearchOption.AllDirectories);
+            // Get all matching files
+            var files = new List<string>();
+            foreach(string filePattern in FilenamePattern)
+            {
+                files.AddRange(Directory.GetFiles(SearchFolder, filePattern, SearchOption.AllDirectories));
+            }
+
+            // Calculate hotlist of files
             List<FileInfo> hotList = new List<FileInfo>();
             foreach (string file in files)
             {

--- a/TailTool/Program/CommandLineOptions.cs
+++ b/TailTool/Program/CommandLineOptions.cs
@@ -10,6 +10,8 @@ namespace TailTool
 
         public List<string> AntiWords { get; set; }
 
+        public List<string> FileNameExtensions { get; set; }
+
         public bool SingleInstance { get; set; }
 
         public bool ShowHelp { get; set; }
@@ -17,11 +19,17 @@ namespace TailTool
         public CommandLineOptions()
         {
             AntiWords = new List<string>();
+            FileNameExtensions = new List<string> { "*.log" };
         }
 
         public void SetAntiWords(string input)
         {
             AntiWords = input.Split(new[]{","}, StringSplitOptions.RemoveEmptyEntries).ToList();
+        }
+
+        public void SetFileNameExtensions(string input)
+        {
+            FileNameExtensions = input.Split(new[] { ",", ";" }, StringSplitOptions.RemoveEmptyEntries).ToList();
         }
     }
 }

--- a/TailTool/Program/CommandLineParser.cs
+++ b/TailTool/Program/CommandLineParser.cs
@@ -14,6 +14,7 @@ namespace TailTool
             OptionSet = new OptionSet {
    	            { "f=|folder=",     v => commandLineArguments.SearchFolder = v },
                 { "a=|antiWords=",  v => { commandLineArguments.SetAntiWords(v); }},
+                { "x=|extensions=", v => { commandLineArguments.SetFileNameExtensions(v); }},
                 { "s|single",       v => commandLineArguments.SingleInstance = true },
    	            { "h|?|help",       v => commandLineArguments.ShowHelp = true },
                };

--- a/TailTool/Program/Program.cs
+++ b/TailTool/Program/Program.cs
@@ -24,7 +24,7 @@ namespace TailTool
             else
             {
                 var fileFinder = new HotFileFinder();
-                fileFinder.FilenamePattern = "*.log";
+                fileFinder.FilenamePattern.AddRange(options.FileNameExtensions);
                 fileFinder.SearchFolder = options.SearchFolder;
                 fileFinder.AntiFilenamePattern.AddRange(options.AntiWords);
                 var matchingFiles = fileFinder.FindMatches();


### PR DESCRIPTION
Which allows you to specify a comma or semicolon separated list of filename patterns to match (eg. _.log,_.txt).
